### PR TITLE
SideBar Image to Canvas

### DIFF
--- a/src/components/Edit/EditToolbar.js
+++ b/src/components/Edit/EditToolbar.js
@@ -8,6 +8,7 @@ const EditToolbar = () => {
     const setPlacingTextbox = useCanvasStore((state) => state.setPlacingTextbox);
     const setPlacingImage = useCanvasStore((state) => state.setPlacingImage);
     const setImageUrl = useCanvasStore((state) => state.setImageUrl);
+    const resetAllSelection = useCanvasStore((state) => state.resetAllSelection);
     const ref = useRef();
 
     return (
@@ -30,12 +31,13 @@ const EditToolbar = () => {
             <button className="item icon select-button">
                 <img src={process.env.PUBLIC_URL + "/images/toolbar_icons/cursor_icon.png"} className="icon select-icon" alt="select"/>
             </button>
-            <button className="item icon textbox-button" onClick={() => setPlacingTextbox(true)}>
+            <button className="item icon textbox-button" onClick={() => {resetAllSelection(); setPlacingTextbox(true)}}>
                 <img src={process.env.PUBLIC_URL + "/images/toolbar_icons/textbox_icon.png"} className="icon textbox-icon" alt="add textbox"/>
             </button>
             
             <input type="file" ref={ref} accept='.png,.jpeg'hidden/> 
             <button className="item icon image-button" onClick={() => {
+                resetAllSelection();
                 ref.current.click();
                 ref.current.onchange = (_) => {
                     const file = ref.current.files[0];

--- a/src/components/Edit/SidebarImage.js
+++ b/src/components/Edit/SidebarImage.js
@@ -23,7 +23,14 @@ const SidebarImage = ({ work }) => {
 
     return (
         <div className="work">
-            <img src={process.env.PUBLIC_URL + work.imageUrl} alt={work.description} />
+            <img 
+                src={process.env.PUBLIC_URL + work.imageUrl} 
+                alt={work.description} 
+                draggable
+                onDragStart={(e) => {
+                    e.dataTransfer.setData('image-url', process.env.PUBLIC_URL + work.imageUrl);
+                }}
+            />
             <div className='work-title' title={work.title}>{work.title}</div>
             <div 
                 className='percentage'

--- a/src/stores/canvasStore.js
+++ b/src/stores/canvasStore.js
@@ -16,6 +16,13 @@ export const useCanvasStore = create((set, get) => ({
 
   imageUrl: '',
   setImageUrl: (url) => set({ imageUrl: url }),
+
+  resetAllSelection: () => {
+    get().setPlacingImage(false);
+    get().setImageUrl('');
+    get().setSelectedObject(null);
+    get().setPlacingTextbox(false);
+  },
   
 
   addTextboxAt: (x, y) => {
@@ -36,26 +43,38 @@ export const useCanvasStore = create((set, get) => ({
 
   addImageAt: (url, x, y) => {
     const canvas = get().canvas;
-
+  
     const image = new Image();
     image.src = url;
-    
-    image.onload = () => { 
+  
+    image.onload = () => {
+      const maxWidth = 500;
+      const maxHeight = 400;
+  
+      let { width, height } = image;
+  
+      // scale proportionally if needed
+      const widthRatio = maxWidth / width;
+      const heightRatio = maxHeight / height;
+      const scale = Math.min(1, widthRatio, heightRatio);
+  
       const fabricImg = new FabricImage(image, {
         left: x,
         top: y,
-        width: 500,
-        height: 400,
+        scaleX: scale,
+        scaleY: scale,
         selectable: true,
         hasControls: true,
         hasBorders: true,
       });
+  
       canvas.add(fabricImg);
       canvas.setActiveObject(fabricImg);
       canvas.requestRenderAll();
+  
       set({ placingImage: false, selectedObject: fabricImg, imageUrl: '' });
     };
-  },
+  },  
 
   deleteSelected: () => {
     const canvas = get().canvas;


### PR DESCRIPTION
- Removed deprecated .pointer and added . viewportPoint
- Added drag and drop functionality with the sidebar
- Added cursor signifiers when adding an image or textbox
- Fixed a glitch where switching between textbox and then adding an image without adding a textbox resulted in adding both a textbox and an image
- Fixed the image to not only be a 500 pixel by 400 pixel image all of the time
- Fixed the image scaling so that only the first 500 pixels by 400 pixels weren't shown and instead the whole image was just scaled down
- 